### PR TITLE
修改失效链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A useful tools or tips list for mobile web application developing
  
  [各种奇妙的hack](http://browserhacks.com/ "各种奇妙的hack")
  
- [几乎所有设备的屏幕尺寸与像素密度表](https://www.google.com/fusiontables/DataSource?docid=1N_eJYR_topuk3xmrOeNhYEsST_LAJikGKKzOQ2o "几乎所有设备的屏幕尺寸与像素密度表")
+ [几乎所有设备的屏幕尺寸与像素密度表](http://pixensity.com/list/ "几乎所有设备的屏幕尺寸与像素密度表")
  
  [移动设备参数表](http://screensiz.es/phone "移动设备参数表")
  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A useful tools or tips list for mobile web application developing
  
  [各种奇妙的hack](http://browserhacks.com/ "各种奇妙的hack")
  
- [几乎所有设备的屏幕尺寸与像素密度表](http://en.wikipedia.org/wiki/List_of_displays_by_pixel_density "几乎所有设备的屏幕尺寸与像素密度表")
+ [几乎所有设备的屏幕尺寸与像素密度表](https://www.google.com/fusiontables/DataSource?docid=1N_eJYR_topuk3xmrOeNhYEsST_LAJikGKKzOQ2o "几乎所有设备的屏幕尺寸与像素密度表")
  
  [移动设备参数表](http://screensiz.es/phone "移动设备参数表")
  


### PR DESCRIPTION
原先指向Wikipedia的链接失效
> Wikipedia does not have an article with this exact name. Please search for List of displays by pixel density in Wikipedia to check for alternative titles or spellings.
新的链接里罗列了不同设备的像素密度表，内容也较为全面